### PR TITLE
cmd/mtex-render: add extra x offset

### DIFF
--- a/cmd/mtex-render/gio.go
+++ b/cmd/mtex-render/gio.go
@@ -289,7 +289,8 @@ func newGioRenderer(gtx C, th *material.Theme, txt string) *gioRenderer {
 	}
 	scale := float32(th.TextSize.V) / float32(ppem)
 
-	r.offset = f32.Pt(0, -scale*float32(met.Height-met.Ascent))
+	// FIXME(sbinet): find out where these -1 offsets come from.
+	r.offset = f32.Pt(-1, -scale*float32(met.Height-met.Ascent)-1)
 	return &r
 }
 

--- a/cmd/mtex-render/go.mod
+++ b/cmd/mtex-render/go.mod
@@ -3,10 +3,10 @@ module github.com/go-latex/latex/cmd/mtex-render
 go 1.13
 
 require (
-	gioui.org v0.0.0-20210114164258-85c0a7d803e8
+	gioui.org v0.0.0-20210118095710-eea1dbc17620
 	github.com/go-fonts/latin-modern v0.2.0
 	github.com/go-fonts/liberation v0.1.1
-	github.com/go-latex/latex v0.0.0-20210114174843-ccdd6a7c6d6e
+	github.com/go-latex/latex v0.0.0-20210118090644-fa023287daff
 	golang.org/x/image v0.0.0-20201208152932-35266b937fa6
 )
 

--- a/cmd/mtex-render/go.sum
+++ b/cmd/mtex-render/go.sum
@@ -1,6 +1,6 @@
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-gioui.org v0.0.0-20210114164258-85c0a7d803e8 h1:IidaVeyqsYpK0jXkMLUPcZdPwlTqWMQdA4DmZovodbE=
-gioui.org v0.0.0-20210114164258-85c0a7d803e8/go.mod h1:Y+uS7hHMvku1Q+ooaoq6fYD5B2LGoT8JtFgvmYmRzTw=
+gioui.org v0.0.0-20210118095710-eea1dbc17620 h1:Xjq1nITuYwA7HbvfDT3Wi/J42kQ61aIhdRgx3xSh/io=
+gioui.org v0.0.0-20210118095710-eea1dbc17620/go.mod h1:Y+uS7hHMvku1Q+ooaoq6fYD5B2LGoT8JtFgvmYmRzTw=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This CL adds an extra 1-pt negative offset so horizontal lines (sqrt) render better.